### PR TITLE
Add Support for UUID Primary Keys

### DIFF
--- a/django_instant_rest/pagination.py
+++ b/django_instant_rest/pagination.py
@@ -38,9 +38,8 @@ def paginate(queryset, first, last, after=None, before=None):
             }
         else:
             fields = decode_cursor(after)
-            id = fields["id"]
             created_at = fields["created_at"]
-            filtered_qs = queryset.filter(id__gt=id, created_at__gt=created_at)
+            filtered_qs = queryset.filter(created_at__gt=created_at)
             extended_page = filtered_qs[:first+1]
             page = extended_page[:first]
             return {
@@ -58,9 +57,8 @@ def paginate(queryset, first, last, after=None, before=None):
             }
         else:
             fields = decode_cursor(before)
-            id = fields["id"]
             created_at = fields["created_at"]
-            filtered_qs = queryset.filter(id__lt=id, created_at__lt=created_at)
+            filtered_qs = queryset.filter(created_at__lt=created_at)
             page = filtered_qs[max(0, len(filtered_qs)-last):]
             return {
                 "page": page,

--- a/django_instant_rest/patterns.py
+++ b/django_instant_rest/patterns.py
@@ -6,7 +6,7 @@ from django.urls import re_path
 # Create a urlpattern element that allows CRUD
 # operations for a given model. 
 def resource(name, model, middleware = None):
-    route = rf"^{name}/(?P<id>.*+)$|^{name}$"
+    route = rf"^{name}/(?P<id>.*)$|^{name}$"
 
     if not middleware:
         return re_path(route, views.resource(model))

--- a/django_instant_rest/patterns.py
+++ b/django_instant_rest/patterns.py
@@ -6,7 +6,7 @@ from django.urls import re_path
 # Create a urlpattern element that allows CRUD
 # operations for a given model. 
 def resource(name, model, middleware = None):
-    route = rf"^{name}/(?P<id>\d+)$|^{name}$"
+    route = rf"^{name}/(?P<id>.*+)$|^{name}$"
 
     if not middleware:
         return re_path(route, views.resource(model))

--- a/django_instant_rest/views.py
+++ b/django_instant_rest/views.py
@@ -152,7 +152,7 @@ def create_one(model):
 
         except Exception:
             # Handling all other errors generically
-            return JsonResponse({ "errors": [invalid_data_err] })
+            return JsonResponse({ "errors": [ str(e) ] })
 
     return request_handler
 


### PR DESCRIPTION
Changes url regex and pagination logic to allow the use of [UUID](https://docs.djangoproject.com/en/3.2/ref/models/fields/#uuidfield) as primary keys.

## Screenshots

Notice the `id` field:

<img width="500" alt="Screen Shot 2021-04-23 at 4 15 47 PM" src="https://user-images.githubusercontent.com/31521775/115934837-95f67880-a457-11eb-83b9-cae5890efaf5.png">
