### PR TITLE
Use order_by querystring parameter

### DIFF
--- a/django_instant_rest/views.py
+++ b/django_instant_rest/views.py
@@ -86,10 +86,12 @@ def read_many(model, camel = False):
         if queryset is None:
             queryset = model.objects.all()
 
-        # Applying queryset ordering if requested
+        # Applying queryset ordering if requested, allowing multiple comma
+        # separated values
         try:
             if "order_by" in params:
-                queryset = queryset.order_by(params["order_by"])
+                order_by_args = params["order_by"].split(",")
+                queryset = queryset.order_by(*order_by_args)
         except:
             pass
 

--- a/django_instant_rest/views.py
+++ b/django_instant_rest/views.py
@@ -53,13 +53,15 @@ def date_fields(model):
     field_names = [f.name for f in model._meta.fields]
     return list(filter(is_date_field, field_names))
 
-
+# A set of query string parameter keys that should not be used for filtering
+filter_key_blacklist = { "order_by", }
 
 def read_many(model, camel = False):
     def request_handler(request):
         params = { key: request.GET.get(key) for key in request.GET }
         queryset = None
 
+        # Parsing datestrings found in params
         for key in params:
             for field in date_fields(model):
                 if key.startswith(field):
@@ -72,13 +74,24 @@ def read_many(model, camel = False):
 
         # Collecting filter parameters
         for key in params:
+            if key in filter_key_blacklist:
+                continue
+
             try:
                 queryset = model.objects.filter(**{key : params[key]})
             except:
                 pass
 
+        # Using the default queryset because no filters were provided
         if queryset is None:
             queryset = model.objects.all()
+
+        # Applying queryset ordering if requested
+        try:
+            if "order_by" in params:
+                queryset = queryset.order_by(params["order_by"])
+        except:
+            pass
 
         # Collecting pagination parameters
         before = params.get("before")


### PR DESCRIPTION
## Description
Allows requesters to include an [`order_by`](https://docs.djangoproject.com/en/3.2/ref/models/querysets/#django.db.models.query.QuerySet.order_by) parameter on GET requests. Multiple values can be passed as a comma-separated string.

## Example HTTP Request
<img width="800" alt="Screen Shot 2021-05-15 at 7 50 29 PM" src="https://user-images.githubusercontent.com/31521775/118382055-d8bef280-b5b6-11eb-81b9-77f60ce35a8b.png">
