### PR TITLE
Prevent Route Clashing / Make Error Objects Uniform

### DIFF
--- a/django_instant_rest/patterns.py
+++ b/django_instant_rest/patterns.py
@@ -6,7 +6,7 @@ from django.urls import re_path
 # Create a urlpattern element that allows CRUD
 # operations for a given model. 
 def resource(name, model, middleware = None, camel=False):
-    route = rf"^{name}/(?P<id>.*)$|^{name}$"
+    route = rf"^{name}/(?!authenticate$)(?P<id>.*)$|^{name}$"
 
     if not middleware:
         return re_path(route, views.resource(model, camel))
@@ -31,7 +31,7 @@ def resource(name, model, middleware = None, camel=False):
 # Create a request handler that allows REST clients to authenticate.
 # In the future, it may be associated with additional actions.
 def client(name, client_model, middleware=None):
-    route = rf"^{name}$"
+    route = rf"^{name}/authenticate$"
 
     if not middleware:
         return re_path(route, views.authenticate(client_model))

--- a/django_instant_rest/patterns.py
+++ b/django_instant_rest/patterns.py
@@ -31,7 +31,7 @@ def resource(name, model, middleware = None, camel=False):
 # Create a request handler that allows REST clients to authenticate.
 # In the future, it may be associated with additional actions.
 def client(name, client_model, middleware=None):
-    route = rf"^{name}/authenticate$"
+    route = rf"^{name}$"
 
     if not middleware:
         return re_path(route, views.authenticate(client_model))

--- a/django_instant_rest/views.py
+++ b/django_instant_rest/views.py
@@ -22,7 +22,8 @@ invalid_data_err = {"message" : "Invalid data type received"}
 unsupported_method_err = {"message" : "Request method not supported by url"}
 invalid_pagination_params_err = {"message" : "Invalid pagination parameters provided"}
 database_integrity_err = {"message" : "The data provided violates database constraints" }
-unknown_storage_error = { "message": "Unable to store the data provided" }
+unknown_storage_err = { "message": "Unable to store the data provided" }
+incorrect_credentials_err = { "message" : "incorrect username/password combination" }
 
 
 def format_validation_error(e: ValidationError, camel=False):
@@ -197,7 +198,7 @@ def create_one(model, camel=False):
 
         # Handling all other errors generically
         except Exception as e:
-            return JsonResponse({ "errors": [ unknown_storage_error ] })
+            return JsonResponse({ "errors": [unknown_storage_err] })
 
     return request_handler
 
@@ -324,7 +325,6 @@ def authenticate(client_model):
             return JsonResponse({ "data": { "token": token } })
 
         except Exception as inst:
-            message = "incorrect username/password combination"
-            return JsonResponse({ 'error': message }, status=400)
+            return JsonResponse({ 'errors': [incorrect_credentials_err] }, status=400)
     
     return handler


### PR DESCRIPTION
Previously, routes created by `patterns.client()` couldn't be accessed if they were matched first by `patterns.resource()`, that mistook "authenticate" as an ID parameter: `/users/authenticate` is matched by `/users/{id}`

An error response has also been changed so that it has the same data shape as other error responses:
`{ "error": "some message" }` -> `{ "errors": [ "some message" ] }`