### PR TITLE
Convert uuids to str in Model.to_dict()

### DIFF
--- a/django_instant_rest/models.py
+++ b/django_instant_rest/models.py
@@ -1,6 +1,7 @@
 from argon2 import PasswordHasher
 from django.db import models
 import datetime
+import uuid
 import jwt
 
 
@@ -23,6 +24,10 @@ class BaseModel(models.Model):
                 continue
 
             value = getattr(self, field.name)
+
+            # Handling UUID fields
+            if type(value) == uuid.UUID:
+                value = str(value)
 
             # Handling datetime fields
             if type(value) == datetime.datetime:
@@ -56,7 +61,6 @@ class RestClient(BaseModel):
     
     class Hashing:
         secret_key = ''
-
 
     def save(self, *args, **kwargs):
         '''Saving the model instance, but first hashing the


### PR DESCRIPTION
Requests to `POST /{model}/authenticate` was broken when model classes use [`model.UUIDField()`](https://docs.djangoproject.com/en/3.2/ref/models/fields/#uuidfield). Calls to `to_dict()` work fine, but UUIDs aren't JSON serializable, so the output of `to_dict()` throws errors when it's passed into `jwt.encode()`